### PR TITLE
nginx.conf optimization&add pid file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -491,8 +491,9 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking
+PIDFile=/etc/nginx/logs/nginx.pid
 ExecStartPre=/etc/nginx/sbin/nginx -t
-ExecStart=/etc/nginx/sbin/nginx
+ExecStart=/etc/nginx/sbin/nginx -c ${nginx_dir}/conf/nginx.conf
 ExecReload=/etc/nginx/sbin/nginx -s reload
 ExecStop=/bin/kill -s QUIT \$MAINPID
 PrivateTmp=true


### PR DESCRIPTION
优化`nginx.conf`;
添加`pid文件`，防止多个实例启动，主要是防止用户自行使用 `service nginx start`这类.
同时记录`nginx`的日志记录，记录错误信息.
OVER