### PR TITLE
修复长连接断开的问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -545,6 +545,7 @@ nginx_conf_add() {
         location /ray/
         {
         proxy_redirect off;
+        proxy_read_timeout 1200s;
         proxy_pass http://127.0.0.1:10000;
         proxy_http_version 1.1;
         proxy_set_header X-Real-IP \$remote_addr;


### PR DESCRIPTION
最近看 fcm 的记录时，发现每次都是大概 60 秒左右就会断开一次。

网上查了下，把  proxy_read_timeout 的超时时间调高就好了。