### PR TITLE
在acme()中添加"--insecure"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -473,7 +473,7 @@ port_exist_check() {
 }
 acme() {
     "$HOME"/.acme.sh/acme.sh --set-default-ca --server letsencrypt
-    if "$HOME"/.acme.sh/acme.sh --issue -d "${domain}" --standalone -k ec-256 --force --test; then
+    if "$HOME"/.acme.sh/acme.sh --issue --insecure -d "${domain}" --standalone -k ec-256 --force --test; then
         echo -e "${OK} ${GreenBG} SSL 证书测试签发成功，开始正式签发 ${Font}"
         rm -rf "$HOME/.acme.sh/${domain}_ecc"
         sleep 2
@@ -483,7 +483,7 @@ acme() {
         exit 1
     fi
 
-    if "$HOME"/.acme.sh/acme.sh --issue -d "${domain}" --standalone -k ec-256 --force; then
+    if "$HOME"/.acme.sh/acme.sh --issue --insecure -d "${domain}" --standalone -k ec-256 --force; then
         echo -e "${OK} ${GreenBG} SSL 证书生成成功 ${Font}"
         sleep 2
         mkdir /data


### PR DESCRIPTION
解决SSL 证书测试签发失败的问题
https://github.com/wulabing/V2Ray_ws-tls_bash_onekey/issues/14
https://github.com/wulabing/V2Ray_ws-tls_bash_onekey/issues/9